### PR TITLE
Adds initial .markdownlint.json file

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+    "default": true,
+    "MD013": false,
+    "MD041": { "level": 2}
+}


### PR DESCRIPTION
Adds support for Markdown linting. No files are changed proactively; this is _informative_ only. Checking in a file that does not resolve all suggestions does not cause failed builds, etc. 

Install VSCode extension here: https://github.com/DavidAnson/vscode-markdownlint