### PR TITLE
Place strings in quotes

### DIFF
--- a/docs/aca/13-appendix/Set-Variables.ps1
+++ b/docs/aca/13-appendix/Set-Variables.ps1
@@ -55,6 +55,12 @@ foreach ($var in $vars) {
 
     if (Test-Path variable:$var) {
         $val = Get-Variable -Name $var -ValueOnly
+
+        # Powershell 7.4.0 requires a bit more type safety by setting quotes around strings.
+        if ($val.GetType().Name -eq "String") {
+            $val = "`"$val`""
+        }
+
         "Set-Variable -Scope Global -Name $var -Value $val" | Out-File -FilePath $file -Append
         $i++
     }


### PR DESCRIPTION
Fixes an issue where PowerShell 7.4.0 now fails if strings are not in quotes.