### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -83,7 +83,7 @@ jobs:
     needs: [ validate ]
     name: Run what-if on the bicep template
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: azure/login@v1
         name: Sign in to Azure
         with:
@@ -105,7 +105,7 @@ jobs:
     if : ${{ vars.CONTAINER_REGISTRY_NAME != '' }}
     needs: [ preview ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: azure/login@v1
         name: Sign in to Azure
         with:
@@ -115,7 +115,7 @@ jobs:
       - name: Create ACR ${{ vars.CONTAINER_REGISTRY_NAME }} if does not exist
         uses: azure/CLI@v1
         with:
-          inlineScript: | 
+          inlineScript: |
             if [[ $(az acr check-name -n ${{ vars.CONTAINER_REGISTRY_NAME }}  -o tsv --query "nameAvailable") == false ]]
             then
               echo "ACR already exists."
@@ -144,7 +144,7 @@ jobs:
     needs: [ create-acr]
     name: Deploy to Azure subscription with ACR
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: azure/login@v1
         name: Sign in to Azure
         with:
@@ -169,7 +169,7 @@ jobs:
     needs: [ preview ]
     name: Deploy to Azure subscription with GHCR
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: azure/login@v1
         name: Sign in to Azure
         with:
@@ -192,7 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     if : ${{ github.event.inputs.teardown == 'true' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: azure/login@v1
         name: Sign in to Azure
         with:

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
       - name: Capture branch and tag

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
       - name: Setup Pages

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -28,7 +28,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       processor: ${{ steps.filter.outputs.processor }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
       id: filter
       with:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
       - name: Capture branch and tag


### PR DESCRIPTION
Some Github Actions are still using the obsolete NodeJS 16. Updating the actions resolves that. Error from a different branch's build:

![image](https://github.com/user-attachments/assets/1c549369-ee2d-4129-87c8-1a377362825e)
