### PR TITLE
Don't overwrite file if no variables are set

### DIFF
--- a/docs/aca/30-appendix/Set-Variables.ps1
+++ b/docs/aca/30-appendix/Set-Variables.ps1
@@ -1,8 +1,6 @@
 $file = "./Variables.ps1"
 $i = 0
-
-# Create a new or replace any existing file (note how we do not use -Append in the first line).
-"# Execute with `"$file`" to restore previously-saved variables." | Out-File -FilePath $file
+$existingVars = 0
 
 $vars = @(
     "ACA_ENVIRONMENT_SUBNET_ID",
@@ -49,6 +47,22 @@ $vars = @(
     "WORKSPACE_NAME",
     "WORKSPACE_SECRET"
 );
+
+# Ensure that variables exist in the terminal session. If none exist, we need to prevent accidental wiping of the Variables.ps1 file.
+foreach ($var in $vars) {
+    if (Test-Path variable:$var) {
+        $existingVars++
+    }
+}
+ 
+if ($existingVars -eq 0) {
+    Write-Host "`nNo variables were found in the current session. Exiting script to prevent accidental overwrite of Variables.ps1 file.`n"
+    exit
+}
+
+# Now that we know variables exist in the current terminal session, we proceed with writing them to the Variables.ps1 file. We replace
+# any existing file with the same name. Note how we intentionally do not use -Append, so that a fresh file gets created here.
+"# Execute with `"$file`" to restore previously-saved variables." | Out-File -FilePath $file
 
 foreach ($var in $vars) { 
     # Ensure the variable exists. If not, don't attempt to get it and don't write out a blank value.


### PR DESCRIPTION
This change narrows the possibility that a user accidentally overwrites the Variables.ps1 file when no variables are present in the terminal session.